### PR TITLE
docs: update README regarding cache file encryption

### DIFF
--- a/.github/workflows/asdf-lint.yml
+++ b/.github/workflows/asdf-lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@v4
 
       - name: Run ShellCheck
         run: bin/scripts/shellcheck.bash
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@v4
 
       - name: List file to shfmt
         run: shfmt -f .

--- a/.github/workflows/asdf-test.yml
+++ b/.github/workflows/asdf-test.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v3
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: type kcc-cache
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v3
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: kcc-injector -h

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Work as caching proxy of [ExecCredential](https://kubernetes.io/docs/reference/c
 - kcc-cache
   - [x] Cache [ExecCredential](https://kubernetes.io/docs/reference/config-api/client-authentication.v1/#client-authentication-k8s-io-v1-ExecCredential) object
   - [x] Concern Command, Args, Env as cache-key
-  - [ ] Cache file encryption
+  - [ ] ~~Cache file encryption~~ (Restricted file permissions `0600`/`0700` like AWS CLI are sufficient)
   - [ ] kubeconfig automated maintenance
 - kcc-injector
   - [x] kubeconfig optimize (inject kcc-cache command automatically)


### PR DESCRIPTION
Update the README to cross out the 'Cache file encryption' todo item, and clarify that the cache file is secured by restricting file permissions (`0600`/`0700`), which is sufficient and matches the security model of the AWS CLI.

---
*PR created automatically by Jules for task [14595530260995361189](https://jules.google.com/task/14595530260995361189) started by @ryodocx*