### PR TITLE
🧹 Refactor environment variable filtering in kcc-injector

### DIFF
--- a/cmd/kcc-injector/main.go
+++ b/cmd/kcc-injector/main.go
@@ -75,22 +75,13 @@ func main() {
 				user.Exec.Args = user.Exec.Args[1:]
 			}
 
-			search := func() (index int) {
-				for i, e := range user.Exec.Env {
-					if e.Name == "KUBE_CREDENTIAL_CACHE_USER" {
-						return i
-					}
+			var newEnv []api.ExecEnvVar
+			for _, e := range user.Exec.Env {
+				if e.Name != "KUBE_CREDENTIAL_CACHE_USER" {
+					newEnv = append(newEnv, e)
 				}
-				return -1
 			}
-
-			for {
-				i := search()
-				if i == -1 {
-					break
-				}
-				user.Exec.Env = append(user.Exec.Env[:i], user.Exec.Env[i+1:]...)
-			}
+			user.Exec.Env = newEnv
 		}
 	} else {
 		// enable cache


### PR DESCRIPTION
🎯 **What:** Replaced the inefficient O(N^2) search-and-slice-shift loop in `cmd/kcc-injector/main.go` with a simple, single-pass O(N) filter to remove the `KUBE_CREDENTIAL_CACHE_USER` environment variable.
💡 **Why:** This refactoring simplifies the code, replacing complex index-tracking and repeated iteration with an idiomatic Go slice append loop. This significantly improves both code readability and execution efficiency.
✅ **Verification:** Verified that the Go compiler outputs a successful build and the test suite passes locally. We reverted unintentional modifications to `go.mod` and `go.sum` generated during environment diagnostics to strictly focus on the target file.
✨ **Result:** The codebase is cleaner and follows Go conventions, avoiding quadratic complexity for slice manipulation while keeping behavior identical.

---
*PR created automatically by Jules for task [11807792628470691007](https://jules.google.com/task/11807792628470691007) started by @ryodocx*