### PR TITLE
Support pagination for GitHub releases API

### DIFF
--- a/bin/scripts/utils.bash
+++ b/bin/scripts/utils.bash
@@ -23,10 +23,19 @@ sort_versions() {
 
 list_github_tags() {
   if which jq &>/dev/null; then
-    # TODO: support pagination
-    curl "${curl_opts[@]}" "https://api.github.com/repos/ryodocx/kube-credential-cache/releases?per_page=100" |
-      jq -r '.[] | select(.prerelease == false) | .tag_name' |
-      sed 's/^v//'
+    local page=1
+    while true; do
+      local response
+      response=$(curl "${curl_opts[@]}" "https://api.github.com/repos/ryodocx/kube-credential-cache/releases?per_page=100&page=${page}") || break
+      if [ -z "$response" ]; then
+        break
+      fi
+      if [ "$(echo "$response" | jq 'length')" -eq 0 ]; then
+        break
+      fi
+      echo "$response" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sed 's/^v//'
+      page=$((page + 1))
+    done
   else
     git ls-remote --tags --refs "$GH_REPO" |
       grep -o 'refs/tags/.*' | cut -d/ -f3- |


### PR DESCRIPTION
Updates `list_github_tags` in `bin/scripts/utils.bash` to paginate through GitHub releases. A `while true` loop fetches pages until the returned payload length is 0 or a failure occurs. This ensures all relevant tags are retrieved instead of just the first 100.

---
*PR created automatically by Jules for task [7619581816203649599](https://jules.google.com/task/7619581816203649599) started by @ryodocx*