### PR TITLE
🧹 Extract duplicated fatal error handling to util package

### DIFF
--- a/cmd/kcc-cache/main.go
+++ b/cmd/kcc-cache/main.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"runtime"
-	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/ryodocx/kube-credential-cache/internal/util"
 )
 
 type CacheFile struct {
@@ -41,14 +41,14 @@ func main() {
 	} else {
 		cacheDir, err := os.UserCacheDir()
 		if err != nil {
-			fatal("can't find CacheDir. fix error or set 'KUBE_CREDENTIAL_CACHE_FILE': %s", err)
+			util.Fatal(nil, "can't find CacheDir. fix error or set 'KUBE_CREDENTIAL_CACHE_FILE': %s", err)
 		}
 		cacheFilepath = path.Join(cacheDir, "kube-credential-cache", "cache.json")
 	}
 	if e := os.Getenv("KUBE_CREDENTIAL_CACHE_REFRESH_MARGIN"); e != "" {
 		d, err := time.ParseDuration(e)
 		if err != nil {
-			fatal("invalid environment variable 'KUBE_CREDENTIAL_CACHE_REFRESH_MARGIN': %s", err.Error())
+			util.Fatal(nil, "invalid environment variable 'KUBE_CREDENTIAL_CACHE_REFRESH_MARGIN': %s", err.Error())
 		}
 		refreshMargin = d
 	}
@@ -77,14 +77,14 @@ func main() {
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(path.Dir(cacheFilepath), 0700); err != nil {
-				fatal("mkdir failed: %s", err)
+				util.Fatal(nil, "mkdir failed: %s", err)
 			}
 			f, err = os.OpenFile(cacheFilepath, os.O_RDWR|os.O_CREATE, 0600)
 			if err != nil {
-				fatal("file open failed(after mkdir): %s", err)
+				util.Fatal(nil, "file open failed(after mkdir): %s", err)
 			}
 		} else {
-			fatal("file open failed: %s", err)
+			util.Fatal(nil, "file open failed: %s", err)
 		}
 	}
 	defer f.Close()
@@ -94,11 +94,11 @@ func main() {
 	cacheFile := CacheFile{}
 	bytes, err := io.ReadAll(f)
 	if err != nil {
-		fatal("file read failed: %s", err)
+		util.Fatal(nil, "file read failed: %s", err)
 	}
 	if len(bytes) > 0 {
 		if err := json.Unmarshal(bytes, &cacheFile); err != nil {
-			log("json.Unmarshal() failed(read cache file): %s\n...Corruption detected, recreate cache file", err)
+			util.Log("json.Unmarshal() failed(read cache file): %s\n...Corruption detected, recreate cache file", err)
 			updated = true
 		}
 	}
@@ -138,7 +138,7 @@ func main() {
 		tmpCache := ClientAuthentication{}
 
 		if len(os.Args) < 2 {
-			fatal("not enough command at args")
+			util.Fatal(nil, "not enough command at args")
 		}
 		cmd := exec.Command(os.Args[1], os.Args[2:]...)
 		cmd.Stderr = os.Stderr
@@ -146,17 +146,17 @@ func main() {
 
 		if err != nil {
 			if len(bytes) > 0 {
-				fatal("read command output failed: %s\nactual stdout: %s", err, string(bytes))
+				util.Fatal(nil, "read command output failed: %s\nactual stdout: %s", err, string(bytes))
 			}
-			fatal("read command output failed: %s", err)
+			util.Fatal(nil, "read command output failed: %s", err)
 		}
 
 		if len(bytes) == 0 {
-			fatal("empty stdout, but without error")
+			util.Fatal(nil, "empty stdout, but without error")
 		}
 
 		if err := json.Unmarshal(bytes, &tmpCache); err != nil {
-			fatal("json.Unmarshal() failed(read command output): %s\nactual stdout: %s", err, string(bytes))
+			util.Fatal(nil, "json.Unmarshal() failed(read command output): %s\nactual stdout: %s", err, string(bytes))
 		}
 
 		cacheFile.Credentials[cacheKey] = tmpCache
@@ -166,29 +166,7 @@ func main() {
 	// print
 	output, err := json.Marshal(cacheFile.Credentials[cacheKey])
 	if err != nil {
-		fatal("json.Marshal() failed: %s", err)
+		util.Fatal(nil, "json.Marshal() failed: %s", err)
 	}
 	fmt.Println(string(output))
-}
-
-func fatal(format string, v ...any) {
-	log(format, v...)
-
-	var commit string = "main"
-	if i, ok := debug.ReadBuildInfo(); ok {
-		for _, v := range i.Settings {
-			if v.Key == "vcs.revision" {
-				commit = v.Value
-			}
-		}
-	}
-	_, _, line, _ := runtime.Caller(1)
-	fmt.Fprintf(os.Stderr, "error occurred at: https://github.com/ryodocx/kube-credential-cache/blob/%s/cmd/kcc-cache/main.go#L%d\n", commit, line)
-
-	os.Exit(1)
-}
-
-func log(format string, v ...any) {
-	fmt.Fprintf(os.Stderr, "%s: ", path.Base(os.Args[0]))
-	fmt.Fprintf(os.Stderr, format+"\n", v...)
 }

--- a/cmd/kcc-injector/main.go
+++ b/cmd/kcc-injector/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
-	"runtime/debug"
 
+	"github.com/ryodocx/kube-credential-cache/internal/util"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -43,7 +42,7 @@ func main() {
 		}
 		b, err := os.ReadFile(filename)
 		if err != nil {
-			fatal("read error: %s", err)
+			util.Fatal(flag.Usage, "read error: %s", err)
 		}
 		bytes = b
 	}
@@ -53,12 +52,12 @@ func main() {
 	{
 		clientConfig, err := clientcmd.NewClientConfigFromBytes(bytes)
 		if err != nil {
-			fatal("%v", err)
+			util.Fatal(flag.Usage, "%v", err)
 		}
 
 		apiConfig, err := clientConfig.RawConfig()
 		if err != nil {
-			fatal("%v", err)
+			util.Fatal(flag.Usage, "%v", err)
 		}
 		kubeConfig = apiConfig
 	}
@@ -125,33 +124,15 @@ func main() {
 		// in-place
 		err := clientcmd.WriteToFile(kubeConfig, filename)
 		if err != nil {
-			fatal("%v", err)
+			util.Fatal(flag.Usage, "%v", err)
 		}
 	} else {
 		// stdout
 		b, err := clientcmd.Write(kubeConfig)
 		if err != nil {
-			fatal("%v", err)
+			util.Fatal(flag.Usage, "%v", err)
 		}
 
 		fmt.Println(string(b))
 	}
-}
-
-func fatal(format string, v ...any) {
-	var commit string = "main"
-	if i, ok := debug.ReadBuildInfo(); ok {
-		for _, v := range i.Settings {
-			if v.Key == "vcs.revision" {
-				commit = v.Value
-			}
-		}
-	}
-	_, _, line, _ := runtime.Caller(1)
-
-	fmt.Fprintf(os.Stderr, "%s: ", path.Base(os.Args[0]))
-	fmt.Fprintf(os.Stderr, format+"\n", v...)
-	fmt.Fprintf(os.Stderr, "error occurred at: https://github.com/ryodocx/kube-credential-cache/blob/%s/cmd/kcc-injector/main.go#L%d\n", commit, line)
-	flag.Usage()
-	os.Exit(1)
 }

--- a/internal/util/fatal.go
+++ b/internal/util/fatal.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+// Fatal prints the error message, the error location, optionally calls usage, and exits.
+func Fatal(usage func(), format string, v ...any) {
+	fmt.Fprintf(os.Stderr, "%s: ", path.Base(os.Args[0]))
+	fmt.Fprintf(os.Stderr, format+"\n", v...)
+
+	var commit string = "main"
+	if i, ok := debug.ReadBuildInfo(); ok {
+		for _, v := range i.Settings {
+			if v.Key == "vcs.revision" {
+				commit = v.Value
+			}
+		}
+	}
+	_, file, line, _ := runtime.Caller(1)
+
+	repoPath := file
+	if idx := strings.Index(file, "kube-credential-cache/"); idx != -1 {
+		repoPath = file[idx+len("kube-credential-cache/"):]
+	} else if idx := strings.LastIndex(file, "cmd/"); idx != -1 {
+		repoPath = file[idx:]
+	} else if idx := strings.LastIndex(file, "app/"); idx != -1 {
+		repoPath = file[idx+len("app/"):]
+	}
+
+	fmt.Fprintf(os.Stderr, "error occurred at: https://github.com/ryodocx/kube-credential-cache/blob/%s/%s#L%d\n", commit, repoPath, line)
+
+	if usage != nil {
+		usage()
+	}
+
+	os.Exit(1)
+}
+
+// Log prints a message with the executable name as a prefix.
+func Log(format string, v ...any) {
+	fmt.Fprintf(os.Stderr, "%s: ", path.Base(os.Args[0]))
+	fmt.Fprintf(os.Stderr, format+"\n", v...)
+}


### PR DESCRIPTION
🎯 **What:** The duplicated `fatal` and `log` functions in `cmd/kcc-cache/main.go` and `cmd/kcc-injector/main.go` have been extracted into a shared `internal/util` package. The original functionality of logging the executable name and exact GitHub URL line number of the caller is preserved.

💡 **Why:** This reduces code duplication and improves maintainability by centralizing error-reporting logic into a single, reusable location.

✅ **Verification:**
- Confirmed that `go build ./...` successfully compiles.
- Confirmed that `go test ./...` passes (no related tests are failing).
- Ran code review to confirm that the logic was safely and properly refactored.
- Checked that binaries (`kcc-cache`, `kcc-injector`) were not included in the commit.

✨ **Result:** A cleaner codebase with centralized error handling, ensuring consistent logging and easier future modifications.

---
*PR created automatically by Jules for task [17918157304688796528](https://jules.google.com/task/17918157304688796528) started by @ryodocx*